### PR TITLE
Upgrade to latest WPILib and PathPlanner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.2.1"
+    id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id "com.peterabeles.gversion" version "1.10.3"
     id "com.diffplug.spotless" version "7.0.2"
 }

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -200,7 +200,7 @@ public class Drive extends SubsystemBase {
                 (voltage) -> runCharacterization(voltage.in(Volts)), null, this));
     // Vision initialization
 
-    aprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+    aprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);
 
     photonPoseEstimatorFrontRight =
         new PhotonPoseEstimator(

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "PathplannerLib.json",
   "name": "PathplannerLib",
-  "version": "2025.2.1",
+  "version": "2025.2.2",
   "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
   "frcYear": "2025",
   "mavenUrls": [
@@ -12,7 +12,7 @@
     {
       "groupId": "com.pathplanner.lib",
       "artifactId": "PathplannerLib-java",
-      "version": "2025.2.1"
+      "version": "2025.2.2"
     }
   ],
   "jniDependencies": [],
@@ -20,7 +20,7 @@
     {
       "groupId": "com.pathplanner.lib",
       "artifactId": "PathplannerLib-cpp",
-      "version": "2025.2.1",
+      "version": "2025.2.2",
       "libName": "PathplannerLib",
       "headerClassifier": "headers",
       "sharedLibrary": false,


### PR DESCRIPTION
Uses the latest release per https://github.com/wpilibsuite/allwpilib/releases/tag/v2025.3.1. Also bumps the `PathPlanner` library.
