### PR TITLE
(Jim's requested changes) 2-sensor update and cancellable centering/gripping process

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -12,11 +12,13 @@ public final class Constants {
   public static final Mode CURRENT_MODE = RobotBase.isReal() ? Mode.REAL : Mode.SIM;
   public static final boolean TUNING_MODE = false;
 
-  // Misc
-  public static final int CORAL_SENSOR_CHANNEL = 0;
+  // Elevator / Flipper / Gripper
+  public static final int CORAL_SENSOR_1_CHANNEL = 0;
+  public static final int CORAL_SENSOR_2_CHANNEL = 1;
   public static final double SECONDS_TO_RAISE_ELEVATOR = 0;
   public static final double SECONDS_TO_SCORE = 0;
   public static final double SECONDS_GRIPPER_DELAY = 0;
+  public static final double SECONDS_PER_CENTERING_ATTEMPT = 2;
 
   // Interface
   public enum InterfaceExecuteMode {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -244,6 +244,7 @@ public class RobotContainer {
     // Driver connection to interface: driver presses button - interface handles.
     // The interface merely exists for the codriver to select locations.
     // The driver controls if and when said selections are actually executed.
+    // The execute button scores, other buttons drive to a location.
     driver.a().onTrue(new InterfaceActionCmd(reef, InterfaceExecuteMode.EXECUTE));
     driver.b().onTrue(new InterfaceActionCmd(reef, InterfaceExecuteMode.REEF));
     driver.x().onTrue(new InterfaceActionCmd(reef, InterfaceExecuteMode.CORAL));

--- a/src/main/java/frc/robot/subsystems/FlipperSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FlipperSubsystem.java
@@ -28,24 +28,29 @@ public class FlipperSubsystem extends SubsystemBase {
   public FlipperSubsystem() {}
 
   /**
-   * If the system thinks it has coral (dropped to the reef or had coral detected by both sensors), it opens
-   * the gripper. <p>If the system doesn't think it has coral (after recieving from station), the coral centerer
-   * will run every 2 seconds until both sensors detect a coral. While doing this, the system will think that it
-   * has coral. <p>Can be cancelled by running the method again.
+   * If the system thinks it has coral (dropped to the reef or had coral detected by both sensors),
+   * it opens the gripper.
+   *
+   * <p>If the system doesn't think it has coral (after recieving from station), the coral centerer
+   * will run every 2 seconds until both sensors detect a coral. While doing this, the system will
+   * think that it has coral.
+   *
+   * <p>Can be cancelled by running the method again.
    */
   public void flipperHoldingState() {
     if (!believesHasCoral) {
       believesHasCoral = true;
       // Repeat until the coral is detected on both sensors or until the user cancels gripping
-      while ((!coralDetector1.get() || !coralDetector2.get()) && believesHasCoral){
+      while ((!coralDetector1.get() || !coralDetector2.get()) && believesHasCoral) {
         coralCenterMechanism.setPulseDuration(0.5);
         coralCenterMechanism.startPulse();
         Timer.delay(Constants.SECONDS_PER_CENTERING_ATTEMPT);
       }
-      // When detected, toggle gripper
-      gripper.set(true);
-    }
-    else if (believesHasCoral) {
+      // If the loop ends normally (not cancelled), turn on gripper
+      if (believesHasCoral) {
+        gripper.set(true);
+      }
+    } else if (believesHasCoral) {
       // Release gripper and stop trying to center the coral
       gripper.set(false);
       coralCenterMechanism.set(false);
@@ -71,10 +76,13 @@ public class FlipperSubsystem extends SubsystemBase {
   public void periodic() {
     Logger.recordOutput("Flipper/Gripper Is Closed", gripper.get());
     Logger.recordOutput("Flipper/Robot Thinks Has Coral", believesHasCoral);
-    Logger.recordOutput("Flipper/Coral Secured", (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
+    Logger.recordOutput(
+        "Flipper/Coral Secured", (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
     SmartDashboard.putBoolean("Gripper Closed", gripper.get());
     SmartDashboard.putBoolean("Thinks has coral", believesHasCoral);
-    SmartDashboard.putBoolean("Coral Secured and Gripped", (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
+    SmartDashboard.putBoolean(
+        "Coral Secured and Gripped",
+        (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/FlipperSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FlipperSubsystem.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.Solenoid;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.*;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
@@ -20,24 +21,32 @@ public class FlipperSubsystem extends SubsystemBase {
       new Solenoid(Constants.SOLENOID_MODULE_TYPE, Constants.FLIPPER_SOLENOID_CHANNEL);
   private Solenoid coralCenterMechanism =
       new Solenoid(Constants.SOLENOID_MODULE_TYPE, Constants.CENTERER_SOLENOID_CHANNEL);
-  private DigitalInput coralDetector = new DigitalInput(Constants.CORAL_SENSOR_CHANNEL);
+  private DigitalInput coralDetector1 = new DigitalInput(Constants.CORAL_SENSOR_1_CHANNEL);
+  private DigitalInput coralDetector2 = new DigitalInput(Constants.CORAL_SENSOR_2_CHANNEL);
 
   /** Subsystem handling coral intake and dropping onto branches/level1. */
   public FlipperSubsystem() {}
 
   /**
-   * If the flipper thinks it has/had coral (aka it dropped to the reef or tried gripping), it opens
-   * the gripper. If the flipper doesn't think it has coral (right after recieving basically), it
-   * centers then grips the coral.
+   * If the system thinks it has coral (dropped to the reef or had coral detected by both sensors), it opens
+   * the gripper. <p>If the system doesn't think it has coral (after recieving from station), the coral centerer
+   * will run every 2 seconds until both sensors detect a coral. While doing this, the system will think that it
+   * has coral. <p>Can be cancelled by running the method again.
    */
   public void flipperHoldingState() {
     if (!believesHasCoral) {
-      coralCenterMechanism.setPulseDuration(0.5);
-      coralCenterMechanism.startPulse();
-      while (coralCenterMechanism.get()) {}
-      gripper.set(coralDetector.get());
       believesHasCoral = true;
-    } else if (believesHasCoral) {
+      // Repeat until the coral is detected on both sensors or until the user cancels gripping
+      while ((!coralDetector1.get() || !coralDetector2.get()) && believesHasCoral){
+        coralCenterMechanism.setPulseDuration(0.5);
+        coralCenterMechanism.startPulse();
+        Timer.delay(Constants.SECONDS_PER_CENTERING_ATTEMPT);
+      }
+      // When detected, toggle gripper
+      gripper.set(true);
+    }
+    else if (believesHasCoral) {
+      // Release gripper and stop trying to center the coral
       gripper.set(false);
       coralCenterMechanism.set(false);
       believesHasCoral = false;
@@ -62,10 +71,10 @@ public class FlipperSubsystem extends SubsystemBase {
   public void periodic() {
     Logger.recordOutput("Flipper/Gripper Is Closed", gripper.get());
     Logger.recordOutput("Flipper/Robot Thinks Has Coral", believesHasCoral);
-    Logger.recordOutput("Flipper/Coral Secured", (gripper.get() && coralDetector.get()));
+    Logger.recordOutput("Flipper/Coral Secured", (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
     SmartDashboard.putBoolean("Gripper Closed", gripper.get());
     SmartDashboard.putBoolean("Thinks has coral", believesHasCoral);
-    SmartDashboard.putBoolean("Coral Secured and Gripped", (gripper.get() && coralDetector.get()));
+    SmartDashboard.putBoolean("Coral Secured and Gripped", (gripper.get() && (coralDetector1.get() && coralDetector2.get())));
   }
 
   @Override


### PR DESCRIPTION
When the flipperHoldingState() method is executed, every two seconds the subsystem will check if both the coral sensors are detecting coral. 
- If both detectors have coral, it will stop centering and then securely grip the coral. 
- If the method is run again while this is happening, it will cancel the centering loop and will not grip afterwards.