### PR TITLE
Exclude empty methods rule from scans and document configuration

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,12 @@
+# Source code location
 sonar.sources=src
+
+# Exclude generated code
 sonar.exclusions=src/main/java/frc/robot/generated/**
+
+# Ignore certain rules
+sonar.issue.ignore.multicriteria=e1
+
+# Empty methods are common in FRC code
+sonar.issue.ignore.multicriteria.e1.ruleKey=java:S1186
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.java


### PR DESCRIPTION
We have a lot of empty methods in code given the FRC interface pattern and this is common / accepted.

Also documents what this configuration file is doing.
