### PR TITLE
Migrate Sonar scanning to Actions

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,8 +14,45 @@ env:
   JAVA_VERSION: 17
 
 jobs:
-  scan:
-    name: Scan
+  sonar-scan:
+    name: Sonar scan
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Cache Sonar packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info
+
+  codeql-scan:
+    name: CodeQL scan
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id "com.peterabeles.gversion" version "1.10.3"
     id "com.diffplug.spotless" version "7.0.2"
+    id "org.sonarqube" version "6.0.1.5171"
 }
 
 java {
@@ -220,5 +221,14 @@ spotless {
         trimTrailingWhitespace()
         leadingTabsToSpaces(2)
         endWithNewline()
+    }
+}
+
+// SonarQube configuration
+sonar {
+    properties {
+        property "sonar.projectKey", "teamresistance_2025_ReefScape"
+        property "sonar.organization", "teamresistance"
+        property "sonar.host.url", "https://sonarcloud.io"
     }
 }


### PR DESCRIPTION
Migrates the Sonar scanning to a GitHub Actions workflow that we can manage more easily and use during CI.
