### PR TITLE
LEDs + One-Driver-Setup

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -71,6 +71,11 @@ public final class Constants {
     REPLAY
   }
 
+  public enum ControlMode {
+    SOLO,
+    DOUBLE
+  }
+
   public enum LEDMode {
     CORAL_OUT,
     ALGAE_OUT,

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -78,7 +78,7 @@ public final class Constants {
     AIR_BAD,
     AIR_LOW,
     AIR_GOOD,
-    CLIMBING,
+    RAINBOW,
     WHITE
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -9,11 +9,6 @@ import edu.wpi.first.wpilibj.RobotBase;
 import frc.robot.generated.TunerConstants;
 import frc.robot.util.LoggedTunableNumber;
 
-/**
- * This class defines the runtime mode used by AdvantageKit. The mode is always "real" when running
- * on a roboRIO. Change the value of "simMode" to switch between "sim" (physics sim) and "replay"
- * (log replay from a file).
- */
 public final class Constants {
   public static final Mode CURRENT_MODE = RobotBase.isReal() ? Mode.REAL : Mode.SIM;
   public static final boolean TUNING_MODE = false;
@@ -60,6 +55,11 @@ public final class Constants {
     ALGEE
   }
 
+  /**
+   * This class defines the runtime mode used by AdvantageKit. The mode is always "real" when running
+   * on a roboRIO. Change the value of "simMode" to switch between "sim" (physics sim) and "replay"
+   * (log replay from a file).
+   */
   public enum Mode {
     /** Running on a real robot. */
     REAL,
@@ -69,5 +69,16 @@ public final class Constants {
 
     /** Replaying from a log file. */
     REPLAY
+  }
+
+  public enum LEDMode {
+    CORAL_OUT,
+    ALGAE_OUT,
+    CORAL_IN,
+    AIR_BAD,
+    AIR_LOW,
+    AIR_GOOD,
+    CLIMBING,
+    WHITE
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -56,9 +56,9 @@ public final class Constants {
   }
 
   /**
-   * This class defines the runtime mode used by AdvantageKit. The mode is always "real" when running
-   * on a roboRIO. Change the value of "simMode" to switch between "sim" (physics sim) and "replay"
-   * (log replay from a file).
+   * This class defines the runtime mode used by AdvantageKit. The mode is always "real" when
+   * running on a roboRIO. Change the value of "simMode" to switch between "sim" (physics sim) and
+   * "replay" (log replay from a file).
    */
   public enum Mode {
     /** Running on a real robot. */

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -103,6 +103,8 @@ public class Robot extends LoggedRobot {
 
     // Return to normal thread priority
     Threads.setCurrentThreadPriority(false, 10);
+
+    robotContainer.updateControlSchemeFromChooser();
   }
 
   /** This function is called once when the robot is disabled. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -339,7 +339,7 @@ public class RobotContainer {
 
     // rainbow when climbed
     new Trigger(climber::getClimberUsed)
-        .onTrue(Commands.runOnce(() -> leds.setMode(Constants.LEDMode.CLIMBING, true)));
+        .onTrue(Commands.runOnce(() -> leds.setMode(Constants.LEDMode.RAINBOW, true)));
 
     // air pressure (these do NOT lock, they only run when others are not running)
     new Trigger(() -> (drive.getPressurePSI() < 40))

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -225,7 +225,8 @@ public class RobotContainer {
             drive, () -> -driver.getLeftY(), () -> -driver.getLeftX(), () -> -driver.getRightX()));
 
     // Switch to X pattern when X button is pressed
-    driver.x().onTrue(Commands.runOnce(drive::stopWithX, drive));
+    // driver.x().onTrue(Commands.runOnce(drive::stopWithX, drive)); // TODO: did this actually have
+    // a use
 
     // Squeeze + grip
     //    driver.leftBumper().onTrue(new FlipperGripperCmd(elevator));
@@ -267,6 +268,7 @@ public class RobotContainer {
                                   .cancel();
                             })));
 
+    // climb
     driver.start().onTrue(new ActivateClimberCommand(climber));
     driver
         .leftTrigger()
@@ -288,8 +290,10 @@ public class RobotContainer {
 
     // driver.povUp().onTrue(new PickupStationCmd(0)); // Change to upper
     // driver.povDown().onTrue(new PickupStationCmd(1)); // Change to lower
-    driver.povLeft().onTrue(new PickupStationCmd(2)); // Change to left
-    driver.povRight().onTrue(new PickupStationCmd(3)); // Change to right
+    //    driver.povLeft().onTrue(new PickupStationCmd(2)); // Change to left
+    //    driver.povRight().onTrue(new PickupStationCmd(3)); // Change to right
+    // TODO: this is only a todo so its highlighted but these were removed because apparently never
+    // used
 
     //    driver
     //        .rightTrigger()
@@ -300,30 +304,134 @@ public class RobotContainer {
     // selected
     //    driver.rightTrigger().onFalse(new InterfaceActionCmd(reef, InterfaceExecuteMode.DISABLE));
 
+    // manual elevator control
+    driver
+        .povUp()
+        .onTrue(
+            new InstantCommand(
+                    () -> {
+                      elevator.centererClosePending = false;
+                      elevator.centerer.set(false);
+                      elevator.setInScoringMode(true);
+                    })
+                .andThen(Commands.waitSeconds(0.18))
+                .andThen(
+                    () -> {
+                      elevator.inHoldingState = true;
+                      elevator.raiseElevator(4);
+                    }));
+    driver
+        .povLeft()
+        .onTrue(
+            new InstantCommand(
+                    () -> {
+                      elevator.centererClosePending = false;
+                      elevator.centerer.set(false);
+                      elevator.setInScoringMode(true);
+                    })
+                .andThen(Commands.waitSeconds(0.18))
+                .andThen(
+                    () -> {
+                      elevator.inHoldingState = true;
+                      elevator.raiseElevator(3);
+                    }));
+    driver
+        .povDown()
+        .onTrue(
+            new InstantCommand(
+                    () -> {
+                      elevator.centererClosePending = false;
+                      elevator.centerer.set(false);
+                      elevator.setInScoringMode(true);
+                    })
+                .andThen(Commands.waitSeconds(0.18))
+                .andThen(
+                    () -> {
+                      elevator.inHoldingState = true;
+                      elevator.raiseElevator(2);
+                    }));
+
+    // right l3
     driver
         .rightTrigger()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
-    driver.rightTrigger().onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE));
+    driver
+        .rightTrigger()
+        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
 
+    // right l4
     driver
         .rightBumper()
         .whileTrue(
-            new InterfaceActionCmd(reef, InterfaceExecuteMode.ALGEE)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, true)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
-    driver.rightBumper().onFalse(new InterfaceActionCmd(reef, InterfaceExecuteMode.DISABLE));
+    driver
+        .rightBumper()
+        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
 
-    driver.b().onTrue(new FlipperScoreCmd(elevator, 1.0));
+    // left l3
+    driver
+        .leftTrigger()
+        .whileTrue(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, false)
+                .andThen(
+                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver
+        .leftTrigger()
+        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
 
-    // We need to find an available button for the gripper toggle command
-    // Since X is already used for X pattern and we want to keep B for scoring
-    // The D-pad is used for pickup station selection
-    // Let's use a button chord (simultaneous button press) combination
+    // left l4
     driver
         .leftBumper()
+        .whileTrue(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, false)
+                .andThen(
+                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver
+        .leftBumper()
+        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+
+    // right l2
+    driver
+            .rightBumper()
+            .whileTrue(
+                    new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, true)
+                            .andThen(
+                                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver
+            .rightBumper()
+            .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
+
+    // left l2
+    driver
+            .leftTrigger()
+            .whileTrue(
+                    new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, false)
+                            .andThen(
+                                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver
+            .leftTrigger()
+            .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+
+    // algae removal
+    driver
+        .y()
+        .whileTrue(
+            new InterfaceActionCmd(reef, InterfaceExecuteMode.ALGEE, -1, false)
+                .andThen(
+                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver.y().onFalse(new InterfaceActionCmd(reef, InterfaceExecuteMode.DISABLE, -1, false));
+
+    // manual drop coral
+    driver.b().onTrue(new FlipperScoreCmd(elevator, 1.0));
+
+    // un-grip
+    driver
+        .x()
         .onTrue(
             new GripperToggleCmd(
                 elevator, true)); // Use B+LB to toggle gripper and reset holding state

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -408,13 +408,13 @@ public class RobotContainer {
 
     // left l2
     driver
-            .leftTrigger()
+            .povRight()
             .whileTrue(
                     new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, false)
                             .andThen(
                                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
-            .leftTrigger()
+            .a()
             .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
 
     // algae removal

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -419,11 +419,11 @@ public class RobotContainer {
         .rightTrigger()
         .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
 
-    // right l4
+    // right l3
     driver
         .rightBumper()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
@@ -452,11 +452,11 @@ public class RobotContainer {
         .leftBumper()
         .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
 
-    // right l2
+    // right l4
     driver
         .rightBumper()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, true)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
@@ -468,6 +468,16 @@ public class RobotContainer {
         .povRight()
         .whileTrue(
             new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, false)
+                .andThen(
+                    () -> {})); // When right trigger is pressed, drive to the location selected
+    driver
+        .povRight()
+        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+    // right l2
+    driver
+        .a()
+        .whileTrue(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, true)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver.a().onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -342,17 +342,17 @@ public class RobotContainer {
 
     // air pressure (these do NOT lock, they only run when others are not running)
     new Trigger(() -> (drive.getPressurePSI() < 40))
-        .onTrue(
+        .whileTrue(
             Commands.runOnce(
                 () ->
                     leds.setMode(Constants.LEDMode.AIR_BAD, false, (int) drive.getPressurePSI())));
     new Trigger(() -> (drive.getPressurePSI() >= 40 && drive.getPressurePSI() < 70))
-        .onTrue(
+        .whileTrue(
             Commands.runOnce(
                 () ->
                     leds.setMode(Constants.LEDMode.AIR_LOW, false, (int) drive.getPressurePSI())));
     new Trigger(() -> (drive.getPressurePSI() >= 70))
-        .onTrue(
+        .whileTrue(
             Commands.runOnce(
                 () ->
                     leds.setMode(Constants.LEDMode.AIR_GOOD, false, (int) drive.getPressurePSI())));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -30,7 +30,6 @@ import frc.robot.subsystems.drive.*;
 import frc.robot.subsystems.vision.Vision;
 import frc.robot.util.GeomUtil;
 import java.io.IOException;
-import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
 import org.photonvision.PhotonCamera;
 
@@ -273,23 +272,25 @@ public class RobotContainer {
 
     // climb
     driver.start().onTrue(new ActivateClimberCommand(climber));
-    driver
-        .leftTrigger()
-        .whileTrue(
-            new DeferredCommand(
-                () -> {
-                  Logger.recordOutput("stationOffset", stationOffsetTransform);
-                  return DriveCommands.goToTransformWithPathFinderPlusOffset(
-                          drive,
-                          stationTargetTransform,
-                          new Transform2d(0.25, 0.0, new Rotation2d(0.0)))
-                      .beforeStarting(
-                          () -> {
-                            DriveCommands.goToTransform(drive, stationTargetTransform).cancel();
-                            DriveCommands.goToTransformWithPathFinder(drive, stationTargetTransform)
-                                .cancel();
-                          });
-                }));
+    //    driver
+    //        .leftTrigger()
+    //        .whileTrue(
+    //            new DeferredCommand(
+    //                () -> {
+    //                  Logger.recordOutput("stationOffset", stationOffsetTransform);
+    //                  return DriveCommands.goToTransformWithPathFinderPlusOffset(
+    //                          drive,
+    //                          stationTargetTransform,
+    //                          new Transform2d(0.25, 0.0, new Rotation2d(0.0)))
+    //                      .beforeStarting(
+    //                          () -> {
+    //                            DriveCommands.goToTransform(drive,
+    // stationTargetTransform).cancel();
+    //                            DriveCommands.goToTransformWithPathFinder(drive,
+    // stationTargetTransform)
+    //                                .cancel();
+    //                          });
+    //                }));
 
     // driver.povUp().onTrue(new PickupStationCmd(0)); // Change to upper
     // driver.povDown().onTrue(new PickupStationCmd(1)); // Change to lower

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -70,6 +70,10 @@ public class RobotContainer {
   private final LoggedDashboardChooser<Command> autoChooser;
   public LoggedDashboardChooser<Integer> cageChooser;
 
+  public LoggedDashboardChooser<Boolean> controlChooser =
+      new LoggedDashboardChooser<Boolean>("Single Driver?");
+  public boolean singleDriver = true;
+
   public boolean testingmode = false;
   public Vision aprilTagVision;
   public boolean ForceClimberUp = false;
@@ -413,75 +417,84 @@ public class RobotContainer {
     driver
         .rightTrigger()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .rightTrigger()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true, singleDriver));
 
     // right l3
     driver
         .rightBumper()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, true, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .rightBumper()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true, singleDriver));
 
     // left l3
     driver
         .leftTrigger()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, false)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 3, false, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .leftTrigger()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false, singleDriver));
 
     // left l4
     driver
         .leftBumper()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, false)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, false, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .leftBumper()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false, singleDriver));
 
     // right l4
     driver
         .rightBumper()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 4, true, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .rightBumper()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, true, singleDriver));
 
     // left l2
     driver
         .povRight()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, false)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, false, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
     driver
         .povRight()
-        .onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false, singleDriver));
     // right l2
     driver
         .a()
         .whileTrue(
-            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, true)
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.REEF, 2, true, singleDriver)
                 .andThen(
                     () -> {})); // When right trigger is pressed, drive to the location selected
-    driver.a().onFalse(new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false));
+    driver
+        .a()
+        .onFalse(
+            new InterfaceActionCmd2(reef, InterfaceExecuteMode.DISABLE, -1, false, singleDriver));
 
     // algae removal
     driver
@@ -579,5 +592,9 @@ public class RobotContainer {
   public void updateCageFromChooser() {
     int selectedCage = cageChooser.get();
     new CageSelectCmd(selectedCage).schedule();
+  }
+
+  public void updateControlSchemeFromChooser() {
+    singleDriver = controlChooser.get();
   }
 }

--- a/src/main/java/frc/robot/commands/InterfaceActionCmd.java
+++ b/src/main/java/frc/robot/commands/InterfaceActionCmd.java
@@ -10,11 +10,16 @@ public class InterfaceActionCmd extends Command {
   private final InterfaceSubsystem subsystem;
   private final InterfaceExecuteMode loc;
   private boolean finished = true;
+  private final int level;
+  private final boolean right;
 
-  public InterfaceActionCmd(InterfaceSubsystem subsystem, InterfaceExecuteMode loc) {
+  public InterfaceActionCmd(
+      InterfaceSubsystem subsystem, InterfaceExecuteMode loc, int level, boolean right) {
     addRequirements(subsystem);
     this.subsystem = subsystem;
     this.loc = loc;
+    this.level = level;
+    this.right = right;
   }
 
   // Called when the command is initially scheduled.
@@ -27,7 +32,7 @@ public class InterfaceActionCmd extends Command {
   @Override
   public void execute() {
     //    Logger.recordOutput("finished work", false);
-    subsystem.driveToLoc(loc, this);
+    subsystem.driveToLoc(loc, this, level, right);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/InterfaceActionCmd2.java
+++ b/src/main/java/frc/robot/commands/InterfaceActionCmd2.java
@@ -12,14 +12,20 @@ public class InterfaceActionCmd2 extends Command {
   private boolean finished = true;
   private final int level;
   private final boolean right;
+  private final boolean singleDriver;
 
   public InterfaceActionCmd2(
-      InterfaceSubsystem subsystem, InterfaceExecuteMode loc, int level, boolean right) {
+      InterfaceSubsystem subsystem,
+      InterfaceExecuteMode loc,
+      int level,
+      boolean right,
+      boolean singleDriver) {
     addRequirements(subsystem);
     this.subsystem = subsystem;
     this.loc = loc;
     this.level = level;
     this.right = right;
+    this.singleDriver = singleDriver;
   }
 
   // Called when the command is initially scheduled.
@@ -32,7 +38,7 @@ public class InterfaceActionCmd2 extends Command {
   @Override
   public void execute() {
     //    Logger.recordOutput("finished work", false);
-    subsystem.driveToLoc2(loc, this, level, right);
+    subsystem.driveToLoc2(loc, this, level, right, singleDriver);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/InterfaceActionCmd2.java
+++ b/src/main/java/frc/robot/commands/InterfaceActionCmd2.java
@@ -10,11 +10,16 @@ public class InterfaceActionCmd2 extends Command {
   private final InterfaceSubsystem subsystem;
   private final InterfaceExecuteMode loc;
   private boolean finished = true;
+  private final int level;
+  private final boolean right;
 
-  public InterfaceActionCmd2(InterfaceSubsystem subsystem, InterfaceExecuteMode loc) {
+  public InterfaceActionCmd2(
+      InterfaceSubsystem subsystem, InterfaceExecuteMode loc, int level, boolean right) {
     addRequirements(subsystem);
     this.subsystem = subsystem;
     this.loc = loc;
+    this.level = level;
+    this.right = right;
   }
 
   // Called when the command is initially scheduled.
@@ -27,7 +32,7 @@ public class InterfaceActionCmd2 extends Command {
   @Override
   public void execute() {
     //    Logger.recordOutput("finished work", false);
-    subsystem.driveToLoc2(loc, this);
+    subsystem.driveToLoc2(loc, this, level, right);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/FlipEleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FlipEleSubsystem.java
@@ -84,6 +84,10 @@ public class FlipEleSubsystem extends SubsystemBase {
     elevatorPusher2.set(false);
   }
 
+  public boolean hasObtainedCoral() {
+    return coralDetector1.get() || coralDetector2.get();
+  }
+
   /**
    * This method is called when the FlipperGripperCmd runs. It now just detects banner sensors and
    * sets flags for the periodic method to handle.

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -3,6 +3,7 @@ package frc.robot.subsystems;
 import static frc.robot.commands.DriveCommands.goToTransform;
 
 import com.pathplanner.lib.auto.AutoBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -58,30 +59,64 @@ public class InterfaceSubsystem extends SubsystemBase {
         FieldConstants.getOffsetApriltagFromTree(allianceplace).getRotation());
   }
 
-  private Transform2d getClosestPole(DriveSubsystem drive) {
+  private Place getClosestPoleGivenRightness(DriveSubsystem drive, boolean isRight) {
     Translation2d now = drive.getPose().getTranslation();
-    Place[] available = {
-            Place.A_TREE, Place.B_TREE, Place.C_TREE, Place.D_TREE,
-            Place.E_TREE, Place.F_TREE, Place.G_TREE, Place.H_TREE,
-            Place.I_TREE, Place.J_TREE, Place.K_TREE, Place.L_TREE
+    Pose2d[] available = {
+      FieldConstants.OFFSET_TAG_7, // Tag 7
+      FieldConstants.OFFSET_TAG_8, // Tag 8
+      FieldConstants.OFFSET_TAG_9, // Tag 9
+      FieldConstants.OFFSET_TAG_10, // Tag 10
+      FieldConstants.OFFSET_TAG_11, // Tag 11
+      FieldConstants.OFFSET_TAG_6, // Tag 6
+      FieldConstants.OFFSET_TAG_18, // Tag 18
+      FieldConstants.OFFSET_TAG_17, // Tag 17
+      FieldConstants.OFFSET_TAG_22, // Tag 22
+      FieldConstants.OFFSET_TAG_21, // Tag 21
+      FieldConstants.OFFSET_TAG_20, // Tag 20
+      FieldConstants.OFFSET_TAG_19 // Tag 19
     };
 
-    Place closestPlace = available[0];
-    double min = now.getDistance(getTranslationFromPlace(available[0]).getTranslation());
+    Pose2d closestTag = available[0];
+    double minDistance = now.getDistance(available[0].getTranslation());
 
-    for (Place check : available) {
-      double dist = now.getDistance(getTranslationFromPlace(check).getTranslation());
-      if (dist < min) {
-        min = dist;
-        closestPlace = check;
+    // Find the closest offset tag
+    for (Pose2d tag : available) {
+      double distance = now.getDistance(tag.getTranslation());
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestTag = tag;
       }
     }
 
-    return getTranslationFromPlace(closestPlace);
+    if (closestTag.equals(FieldConstants.OFFSET_TAG_7)) {
+      return isRight ? Place.B_TREE : Place.A_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_8)) {
+      return isRight ? Place.D_TREE : Place.C_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_9)) {
+      return isRight ? Place.F_TREE : Place.E_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_10)) {
+      return isRight ? Place.H_TREE : Place.G_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_11)) {
+      return isRight ? Place.J_TREE : Place.I_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_6)) {
+      return isRight ? Place.L_TREE : Place.K_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_18)) {
+      return isRight ? Place.B_TREE : Place.A_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_17)) {
+      return isRight ? Place.D_TREE : Place.C_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_22)) {
+      return isRight ? Place.F_TREE : Place.E_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_21)) {
+      return isRight ? Place.H_TREE : Place.G_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_20)) {
+      return isRight ? Place.J_TREE : Place.I_TREE;
+    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_19)) {
+      return isRight ? Place.L_TREE : Place.K_TREE;
+    }
+    return null;
   }
 
-  private void executeDrive(
-      Transform2d targetTransform, boolean isRight, boolean useOffset) {
+  private void executeDrive(Transform2d targetTransform, boolean isRight, boolean useOffset) {
     if (useOffset) {
       if (isRight) {
         leftRightOffset = new Transform2d(0.50, -0.24, new Rotation2d(Units.degreesToRadians(0.0)));
@@ -136,16 +171,17 @@ public class InterfaceSubsystem extends SubsystemBase {
     CommandScheduler.getInstance().schedule(drive_command);
   }
 
-  public void driveToLoc(InterfaceExecuteMode loc, InterfaceActionCmd stuff) {
-    boolean isRight = false;
+  public void driveToLoc(
+      InterfaceExecuteMode loc, InterfaceActionCmd stuff, int lvl, boolean isRight) {
+    if (lvl != -1) level = lvl - 1;
     switch (loc) {
       case REEF:
-        targetTransform = getClosestPole(drive);
+        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
         executeDrive(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        targetTransform = getClosestPole(drive);
+        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
         executeDrive(targetTransform, isRight, false);
         break;
 
@@ -177,8 +213,7 @@ public class InterfaceSubsystem extends SubsystemBase {
     }
   }
 
-  private void executeDrive2(
-      Transform2d targetTransform, boolean isRight, boolean useOffset) {
+  private void executeDrive2(Transform2d targetTransform, boolean isRight, boolean useOffset) {
     if (useOffset) {
       if (isRight) {
         leftRightOffset = new Transform2d(0.52, -0.24, new Rotation2d(Units.degreesToRadians(0.0)));
@@ -262,16 +297,17 @@ public class InterfaceSubsystem extends SubsystemBase {
     CommandScheduler.getInstance().schedule(drive_command);
   }
 
-  public void driveToLoc2(InterfaceExecuteMode loc, InterfaceActionCmd2 stuff) {
-    boolean isRight = false;
+  public void driveToLoc2(
+      InterfaceExecuteMode loc, InterfaceActionCmd2 stuff, int lvl, boolean isRight) {
+    if (lvl != -1) level = lvl - 1;
     switch (loc) {
       case REEF:
-        targetTransform = getClosestPole(drive);
+        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
         executeDrive2(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        targetTransform = getClosestPole(drive);
+        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
         executeDrive2(targetTransform, isRight, false);
         break;
       case CORAL:

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -58,8 +58,30 @@ public class InterfaceSubsystem extends SubsystemBase {
         FieldConstants.getOffsetApriltagFromTree(allianceplace).getRotation());
   }
 
+  private Transform2d getClosestPole(DriveSubsystem drive) {
+    Translation2d now = drive.getPose().getTranslation();
+    Place[] available = {
+            Place.A_TREE, Place.B_TREE, Place.C_TREE, Place.D_TREE,
+            Place.E_TREE, Place.F_TREE, Place.G_TREE, Place.H_TREE,
+            Place.I_TREE, Place.J_TREE, Place.K_TREE, Place.L_TREE
+    };
+
+    Place closestPlace = available[0];
+    double min = now.getDistance(getTranslationFromPlace(available[0]).getTranslation());
+
+    for (Place check : available) {
+      double dist = now.getDistance(getTranslationFromPlace(check).getTranslation());
+      if (dist < min) {
+        min = dist;
+        closestPlace = check;
+      }
+    }
+
+    return getTranslationFromPlace(closestPlace);
+  }
+
   private void executeDrive(
-      Transform2d targetTransform, boolean isRight, boolean useOffset, InterfaceActionCmd stuff) {
+      Transform2d targetTransform, boolean isRight, boolean useOffset) {
     if (useOffset) {
       if (isRight) {
         leftRightOffset = new Transform2d(0.50, -0.24, new Rotation2d(Units.degreesToRadians(0.0)));
@@ -118,104 +140,18 @@ public class InterfaceSubsystem extends SubsystemBase {
     boolean isRight = false;
     switch (loc) {
       case REEF:
-        switch (pole) {
-          case "a":
-            targetTransform = getTranslationFromPlace(Place.A_TREE);
-            break;
-          case "b":
-            targetTransform = getTranslationFromPlace(Place.B_TREE);
-            isRight = true;
-            break;
-          case "c":
-            targetTransform = getTranslationFromPlace(Place.C_TREE);
-            break;
-          case "d":
-            targetTransform = getTranslationFromPlace(Place.D_TREE);
-            isRight = true;
-            break;
-          case "e":
-            targetTransform = getTranslationFromPlace(Place.E_TREE);
-            break;
-          case "f":
-            targetTransform = getTranslationFromPlace(Place.F_TREE);
-            isRight = true;
-            break;
-          case "g":
-            targetTransform = getTranslationFromPlace(Place.G_TREE);
-            break;
-          case "h":
-            targetTransform = getTranslationFromPlace(Place.H_TREE);
-            isRight = true;
-            break;
-          case "i":
-            targetTransform = getTranslationFromPlace(Place.I_TREE);
-            break;
-          case "j":
-            targetTransform = getTranslationFromPlace(Place.J_TREE);
-            isRight = true;
-            break;
-          case "k":
-            targetTransform = getTranslationFromPlace(Place.K_TREE);
-            break;
-          case "l":
-            targetTransform = getTranslationFromPlace(Place.L_TREE);
-            isRight = true;
-            break;
-        }
-        executeDrive(targetTransform, isRight, true, stuff);
+        targetTransform = getClosestPole(drive);
+        executeDrive(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        switch (pole) {
-          case "a":
-            targetTransform = getTranslationFromPlace(Place.A_TREE);
-            break;
-          case "b":
-            targetTransform = getTranslationFromPlace(Place.B_TREE);
-            isRight = true;
-            break;
-          case "c":
-            targetTransform = getTranslationFromPlace(Place.C_TREE);
-            break;
-          case "d":
-            targetTransform = getTranslationFromPlace(Place.D_TREE);
-            isRight = true;
-            break;
-          case "e":
-            targetTransform = getTranslationFromPlace(Place.E_TREE);
-            break;
-          case "f":
-            targetTransform = getTranslationFromPlace(Place.F_TREE);
-            isRight = true;
-            break;
-          case "g":
-            targetTransform = getTranslationFromPlace(Place.G_TREE);
-            break;
-          case "h":
-            targetTransform = getTranslationFromPlace(Place.H_TREE);
-            isRight = true;
-            break;
-          case "i":
-            targetTransform = getTranslationFromPlace(Place.I_TREE);
-            break;
-          case "j":
-            targetTransform = getTranslationFromPlace(Place.J_TREE);
-            isRight = true;
-            break;
-          case "k":
-            targetTransform = getTranslationFromPlace(Place.K_TREE);
-            break;
-          case "l":
-            targetTransform = getTranslationFromPlace(Place.L_TREE);
-            isRight = true;
-            break;
-        }
-        executeDrive(targetTransform, isRight, false, stuff);
+        targetTransform = getClosestPole(drive);
+        executeDrive(targetTransform, isRight, false);
         break;
 
       case CORAL:
         targetTransform = getTranslationFromPlace(Place.LEFT_CORAL_STATION);
-        executeDrive(targetTransform, false, false, stuff);
+        executeDrive(targetTransform, false, false);
         break;
 
       case DISABLE:
@@ -225,7 +161,7 @@ public class InterfaceSubsystem extends SubsystemBase {
 
       case CLIMBER:
         targetTransform = getTranslationFromPlace(Place.MIDDLE_CAGE);
-        executeDrive(targetTransform, false, false, stuff);
+        executeDrive(targetTransform, false, false);
         break;
 
       case EXECUTE:
@@ -242,7 +178,7 @@ public class InterfaceSubsystem extends SubsystemBase {
   }
 
   private void executeDrive2(
-      Transform2d targetTransform, boolean isRight, boolean useOffset, InterfaceActionCmd2 stuff) {
+      Transform2d targetTransform, boolean isRight, boolean useOffset) {
     if (useOffset) {
       if (isRight) {
         leftRightOffset = new Transform2d(0.52, -0.24, new Rotation2d(Units.degreesToRadians(0.0)));
@@ -330,103 +266,17 @@ public class InterfaceSubsystem extends SubsystemBase {
     boolean isRight = false;
     switch (loc) {
       case REEF:
-        switch (pole) {
-          case "a":
-            targetTransform = getTranslationFromPlace(Place.A_TREE);
-            break;
-          case "b":
-            targetTransform = getTranslationFromPlace(Place.B_TREE);
-            isRight = true;
-            break;
-          case "c":
-            targetTransform = getTranslationFromPlace(Place.C_TREE);
-            break;
-          case "d":
-            targetTransform = getTranslationFromPlace(Place.D_TREE);
-            isRight = true;
-            break;
-          case "e":
-            targetTransform = getTranslationFromPlace(Place.E_TREE);
-            break;
-          case "f":
-            targetTransform = getTranslationFromPlace(Place.F_TREE);
-            isRight = true;
-            break;
-          case "g":
-            targetTransform = getTranslationFromPlace(Place.G_TREE);
-            break;
-          case "h":
-            targetTransform = getTranslationFromPlace(Place.H_TREE);
-            isRight = true;
-            break;
-          case "i":
-            targetTransform = getTranslationFromPlace(Place.I_TREE);
-            break;
-          case "j":
-            targetTransform = getTranslationFromPlace(Place.J_TREE);
-            isRight = true;
-            break;
-          case "k":
-            targetTransform = getTranslationFromPlace(Place.K_TREE);
-            break;
-          case "l":
-            targetTransform = getTranslationFromPlace(Place.L_TREE);
-            isRight = true;
-            break;
-        }
-        executeDrive2(targetTransform, isRight, true, stuff);
+        targetTransform = getClosestPole(drive);
+        executeDrive2(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        switch (pole) {
-          case "a":
-            targetTransform = getTranslationFromPlace(Place.A_TREE);
-            break;
-          case "b":
-            targetTransform = getTranslationFromPlace(Place.B_TREE);
-            isRight = true;
-            break;
-          case "c":
-            targetTransform = getTranslationFromPlace(Place.C_TREE);
-            break;
-          case "d":
-            targetTransform = getTranslationFromPlace(Place.D_TREE);
-            isRight = true;
-            break;
-          case "e":
-            targetTransform = getTranslationFromPlace(Place.E_TREE);
-            break;
-          case "f":
-            targetTransform = getTranslationFromPlace(Place.F_TREE);
-            isRight = true;
-            break;
-          case "g":
-            targetTransform = getTranslationFromPlace(Place.G_TREE);
-            break;
-          case "h":
-            targetTransform = getTranslationFromPlace(Place.H_TREE);
-            isRight = true;
-            break;
-          case "i":
-            targetTransform = getTranslationFromPlace(Place.I_TREE);
-            break;
-          case "j":
-            targetTransform = getTranslationFromPlace(Place.J_TREE);
-            isRight = true;
-            break;
-          case "k":
-            targetTransform = getTranslationFromPlace(Place.K_TREE);
-            break;
-          case "l":
-            targetTransform = getTranslationFromPlace(Place.L_TREE);
-            isRight = true;
-            break;
-        }
-        executeDrive2(targetTransform, isRight, false, stuff);
+        targetTransform = getClosestPole(drive);
+        executeDrive2(targetTransform, isRight, false);
         break;
       case CORAL:
         targetTransform = getTranslationFromPlace(Place.LEFT_CORAL_STATION);
-        executeDrive2(targetTransform, false, false, stuff);
+        executeDrive2(targetTransform, false, false);
         break;
       case DISABLE:
         drive_command.cancel();
@@ -435,7 +285,7 @@ public class InterfaceSubsystem extends SubsystemBase {
         break;
       case CLIMBER:
         targetTransform = getTranslationFromPlace(Place.MIDDLE_CAGE);
-        executeDrive2(targetTransform, false, false, stuff);
+        executeDrive2(targetTransform, false, false);
         break;
       case EXECUTE:
         if (!executing) {

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -304,39 +304,166 @@ public class InterfaceSubsystem extends SubsystemBase {
   }
 
   public void driveToLoc2(
-      InterfaceExecuteMode loc, InterfaceActionCmd2 stuff, int lvl, boolean isRight) {
-    if (lvl != -1) level = lvl;
-    AutoAlignParams params = new AutoAlignParams(drive, isRight);
-    switch (loc) {
-      case REEF:
-        executeDrive2(params.targetTransform, params.isRight, true);
-        break;
+      InterfaceExecuteMode loc,
+      InterfaceActionCmd2 stuff,
+      int lvl,
+      boolean isRight,
+      boolean singleDriver) {
+    if (singleDriver) {
+      if (lvl != -1) level = lvl;
+      AutoAlignParams params = new AutoAlignParams(drive, isRight);
+      switch (loc) {
+        case REEF:
+          executeDrive2(params.targetTransform, params.isRight, true);
+          break;
 
-      case ALGEE:
-        executeDrive2(params.targetTransform, params.isRight, false);
-        break;
-      case CORAL:
-        targetTransform = getTranslationFromPlace(Place.LEFT_CORAL_STATION);
-        executeDrive2(targetTransform, false, false);
-        break;
-      case DISABLE:
-        drive_command.cancel();
-        elevator.raiseElevator(0);
-        elevator.resetAutoscoreState();
-        break;
-      case CLIMBER:
-        targetTransform = getTranslationFromPlace(Place.MIDDLE_CAGE);
-        executeDrive2(targetTransform, false, false);
-        break;
-      case EXECUTE:
-        if (!executing) {
-          executeSelected();
-        } else {
-          forceStopExecution();
-        }
-        break;
-      default:
-        // Do nothing
+        case ALGEE:
+          executeDrive2(params.targetTransform, params.isRight, false);
+          break;
+        case CORAL:
+          targetTransform = getTranslationFromPlace(Place.LEFT_CORAL_STATION);
+          executeDrive2(targetTransform, false, false);
+          break;
+        case DISABLE:
+          drive_command.cancel();
+          elevator.raiseElevator(0);
+          elevator.resetAutoscoreState();
+          break;
+        case CLIMBER:
+          targetTransform = getTranslationFromPlace(Place.MIDDLE_CAGE);
+          executeDrive2(targetTransform, false, false);
+          break;
+        case EXECUTE:
+          if (!executing) {
+            executeSelected();
+          } else {
+            forceStopExecution();
+          }
+          break;
+        default:
+          // Do nothing
+      }
+    } else {
+      boolean isRighty = false;
+      switch (loc) {
+        case REEF:
+          switch (pole) {
+            case "a":
+              targetTransform = getTranslationFromPlace(Place.A_TREE);
+              break;
+            case "b":
+              targetTransform = getTranslationFromPlace(Place.B_TREE);
+              isRighty = true;
+              break;
+            case "c":
+              targetTransform = getTranslationFromPlace(Place.C_TREE);
+              break;
+            case "d":
+              targetTransform = getTranslationFromPlace(Place.D_TREE);
+              isRighty = true;
+              break;
+            case "e":
+              targetTransform = getTranslationFromPlace(Place.E_TREE);
+              break;
+            case "f":
+              targetTransform = getTranslationFromPlace(Place.F_TREE);
+              isRighty = true;
+              break;
+            case "g":
+              targetTransform = getTranslationFromPlace(Place.G_TREE);
+              break;
+            case "h":
+              targetTransform = getTranslationFromPlace(Place.H_TREE);
+              isRighty = true;
+              break;
+            case "i":
+              targetTransform = getTranslationFromPlace(Place.I_TREE);
+              break;
+            case "j":
+              targetTransform = getTranslationFromPlace(Place.J_TREE);
+              isRighty = true;
+              break;
+            case "k":
+              targetTransform = getTranslationFromPlace(Place.K_TREE);
+              break;
+            case "l":
+              targetTransform = getTranslationFromPlace(Place.L_TREE);
+              isRighty = true;
+              break;
+          }
+          executeDrive2(targetTransform, isRighty, true);
+          break;
+
+        case ALGEE:
+          switch (pole) {
+            case "a":
+              targetTransform = getTranslationFromPlace(Place.A_TREE);
+              break;
+            case "b":
+              targetTransform = getTranslationFromPlace(Place.B_TREE);
+              isRighty = true;
+              break;
+            case "c":
+              targetTransform = getTranslationFromPlace(Place.C_TREE);
+              break;
+            case "d":
+              targetTransform = getTranslationFromPlace(Place.D_TREE);
+              isRighty = true;
+              break;
+            case "e":
+              targetTransform = getTranslationFromPlace(Place.E_TREE);
+              break;
+            case "f":
+              targetTransform = getTranslationFromPlace(Place.F_TREE);
+              isRighty = true;
+              break;
+            case "g":
+              targetTransform = getTranslationFromPlace(Place.G_TREE);
+              break;
+            case "h":
+              targetTransform = getTranslationFromPlace(Place.H_TREE);
+              isRighty = true;
+              break;
+            case "i":
+              targetTransform = getTranslationFromPlace(Place.I_TREE);
+              break;
+            case "j":
+              targetTransform = getTranslationFromPlace(Place.J_TREE);
+              isRighty = true;
+              break;
+            case "k":
+              targetTransform = getTranslationFromPlace(Place.K_TREE);
+              break;
+            case "l":
+              targetTransform = getTranslationFromPlace(Place.L_TREE);
+              isRighty = true;
+              break;
+          }
+          executeDrive2(targetTransform, isRighty, false);
+          break;
+        case CORAL:
+          targetTransform = getTranslationFromPlace(Place.LEFT_CORAL_STATION);
+          executeDrive2(targetTransform, false, false);
+          break;
+        case DISABLE:
+          drive_command.cancel();
+          elevator.raiseElevator(0);
+          elevator.resetAutoscoreState();
+          break;
+        case CLIMBER:
+          targetTransform = getTranslationFromPlace(Place.MIDDLE_CAGE);
+          executeDrive2(targetTransform, false, false);
+          break;
+        case EXECUTE:
+          if (!executing) {
+            executeSelected();
+          } else {
+            forceStopExecution();
+          }
+          break;
+        default:
+          // Do nothing
+      }
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -23,9 +23,9 @@ import frc.robot.util.GeomUtil;
 import org.littletonrobotics.junction.Logger;
 
 /**
- * Utility class for auto alignment to reef.
- * Contains closest-face and left/right inversion in the constructor
- * */
+ * Utility class for auto alignment to reef. Contains closest-face and left/right inversion in the
+ * constructor
+ */
 class AutoAlignParams {
 
   Transform2d targetTransform;
@@ -38,13 +38,7 @@ class AutoAlignParams {
     // compensate for velocity (although x side is closer, it may be faster
     // to get to y side depending on the robot already moving that way, not
     // needing to change direction)
-    now =
-        now.plus(
-            drive
-                .getVelocity()
-                .getTranslation()
-                .times(
-                    0.15));
+    now = now.plus(drive.getVelocity().getTranslation().times(0.15));
 
     Pose2d[] available = {
       FieldConstants.OFFSET_TAG_7, // Tag 7 --0

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -89,9 +89,7 @@ public class InterfaceSubsystem extends SubsystemBase {
     }
 
     return new Transform2d(
-            new Translation2d(closestTag.getX(), closestTag.getY()),
-            closestTag.getRotation()
-    );
+        new Translation2d(closestTag.getX(), closestTag.getY()), closestTag.getRotation());
   }
 
   private void executeDrive(Transform2d targetTransform, boolean isRight, boolean useOffset) {

--- a/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/InterfaceSubsystem.java
@@ -59,7 +59,7 @@ public class InterfaceSubsystem extends SubsystemBase {
         FieldConstants.getOffsetApriltagFromTree(allianceplace).getRotation());
   }
 
-  private Place getClosestPoleGivenRightness(DriveSubsystem drive, boolean isRight) {
+  private Transform2d getTargetTransformAutomatically(DriveSubsystem drive) {
     Translation2d now = drive.getPose().getTranslation();
     Pose2d[] available = {
       FieldConstants.OFFSET_TAG_7, // Tag 7
@@ -88,32 +88,10 @@ public class InterfaceSubsystem extends SubsystemBase {
       }
     }
 
-    if (closestTag.equals(FieldConstants.OFFSET_TAG_7)) {
-      return isRight ? Place.B_TREE : Place.A_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_8)) {
-      return isRight ? Place.D_TREE : Place.C_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_9)) {
-      return isRight ? Place.F_TREE : Place.E_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_10)) {
-      return isRight ? Place.H_TREE : Place.G_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_11)) {
-      return isRight ? Place.J_TREE : Place.I_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_6)) {
-      return isRight ? Place.L_TREE : Place.K_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_18)) {
-      return isRight ? Place.B_TREE : Place.A_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_17)) {
-      return isRight ? Place.D_TREE : Place.C_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_22)) {
-      return isRight ? Place.F_TREE : Place.E_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_21)) {
-      return isRight ? Place.H_TREE : Place.G_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_20)) {
-      return isRight ? Place.J_TREE : Place.I_TREE;
-    } else if (closestTag.equals(FieldConstants.OFFSET_TAG_19)) {
-      return isRight ? Place.L_TREE : Place.K_TREE;
-    }
-    return null;
+    return new Transform2d(
+            new Translation2d(closestTag.getX(), closestTag.getY()),
+            closestTag.getRotation()
+    );
   }
 
   private void executeDrive(Transform2d targetTransform, boolean isRight, boolean useOffset) {
@@ -173,15 +151,15 @@ public class InterfaceSubsystem extends SubsystemBase {
 
   public void driveToLoc(
       InterfaceExecuteMode loc, InterfaceActionCmd stuff, int lvl, boolean isRight) {
-    if (lvl != -1) level = lvl - 1;
+    if (lvl != -1) level = lvl;
     switch (loc) {
       case REEF:
-        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
+        targetTransform = getTargetTransformAutomatically(drive);
         executeDrive(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
+        targetTransform = getTargetTransformAutomatically(drive);
         executeDrive(targetTransform, isRight, false);
         break;
 
@@ -299,15 +277,15 @@ public class InterfaceSubsystem extends SubsystemBase {
 
   public void driveToLoc2(
       InterfaceExecuteMode loc, InterfaceActionCmd2 stuff, int lvl, boolean isRight) {
-    if (lvl != -1) level = lvl - 1;
+    if (lvl != -1) level = lvl;
     switch (loc) {
       case REEF:
-        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
+        targetTransform = getTargetTransformAutomatically(drive);
         executeDrive2(targetTransform, isRight, true);
         break;
 
       case ALGEE:
-        targetTransform = getTranslationFromPlace(getClosestPoleGivenRightness(drive, isRight));
+        targetTransform = getTargetTransformAutomatically(drive);
         executeDrive2(targetTransform, isRight, false);
         break;
       case CORAL:

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -17,7 +17,7 @@ public class LEDSubsystem extends SubsystemBase {
   private final int LED_END_INDEX = 67;
   private final CANdle candle = new CANdle(60); // TODO: correct port
   private int psi = 120;
-  private LEDMode mode = LEDMode.WHITE;
+  private LEDMode mode = LEDMode.CLIMBING;
   private boolean isLocked = false;
 
   public void setMode(LEDMode newMode, boolean lock) {

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -67,21 +67,25 @@ public class LEDSubsystem extends SubsystemBase {
         break;
       case RAINBOW:
         candle.setControl(new RainbowAnimation(LED_START_INDEX, LED_END_INDEX).withFrameRate(60));
+        break;
       case AIR_GOOD: // >70
         candle.setControl(
             new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
                 .withColor(new RGBWColor(186, 85, 211))
                 .withFrameRate(2 * psi));
+        break;
       case AIR_LOW: // 40-70
         candle.setControl(
             new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
                 .withColor(new RGBWColor(255, 255, 0))
                 .withFrameRate(4 * psi));
+        break;
       case AIR_BAD: // <40
         candle.setControl(
             new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
                 .withColor(new RGBWColor(200, 0, 0))
                 .withFrameRate(8 * psi));
+        break;
     }
   }
 }

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -6,6 +6,7 @@ import com.ctre.phoenix6.controls.SolidColor;
 import com.ctre.phoenix6.controls.StrobeAnimation;
 import com.ctre.phoenix6.hardware.CANdle;
 import com.ctre.phoenix6.signals.RGBWColor;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.LEDMode;
 
@@ -17,7 +18,7 @@ public class LEDSubsystem extends SubsystemBase {
   private final int LED_END_INDEX = 67;
   private final CANdle candle = new CANdle(60); // TODO: correct port
   private int psi = 120;
-  private LEDMode mode = LEDMode.CLIMBING;
+  private LEDMode mode = LEDMode.RAINBOW;
   private boolean isLocked = false;
 
   public void setMode(LEDMode newMode, boolean lock) {
@@ -37,6 +38,8 @@ public class LEDSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
+
+    SmartDashboard.putString("LED Mode", mode.toString());
 
     // auto set led
     switch (mode) {
@@ -62,7 +65,7 @@ public class LEDSubsystem extends SubsystemBase {
                 .withFrameRate(8)
                 .withColor(new RGBWColor(255, 255, 255)));
         break;
-      case CLIMBING:
+      case RAINBOW:
         candle.setControl(new RainbowAnimation(LED_START_INDEX, LED_END_INDEX).withFrameRate(60));
       case AIR_GOOD: // >70
         candle.setControl(

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -1,0 +1,84 @@
+package frc.robot.subsystems;
+
+import com.ctre.phoenix6.controls.RainbowAnimation;
+import com.ctre.phoenix6.controls.SingleFadeAnimation;
+import com.ctre.phoenix6.controls.SolidColor;
+import com.ctre.phoenix6.controls.StrobeAnimation;
+import com.ctre.phoenix6.hardware.CANdle;
+import com.ctre.phoenix6.signals.RGBWColor;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.LEDMode;
+
+public class LEDSubsystem extends SubsystemBase {
+
+  public LEDSubsystem() {}
+
+  private final int LED_START_INDEX = 8;
+  private final int LED_END_INDEX = 67;
+  private final CANdle candle = new CANdle(60); // TODO: correct port
+  private int psi = 120;
+  private LEDMode mode = LEDMode.WHITE;
+  private boolean isLocked = false;
+
+  public void setMode(LEDMode newMode, boolean lock) {
+    if (!isLocked) mode = newMode;
+    if (lock) isLocked = true;
+  }
+
+  public void setMode(LEDMode newMode, boolean lock, int psi) {
+    if (!isLocked) mode = newMode;
+    if (lock) isLocked = true;
+    this.psi = psi;
+  }
+
+  public void unlock() {
+    isLocked = false;
+  }
+
+  @Override
+  public void periodic() {
+
+    // auto set led
+    switch (mode) {
+      case WHITE:
+        candle.setControl(
+            new SolidColor(LED_START_INDEX, LED_END_INDEX).withColor(new RGBWColor(255, 255, 255)));
+        break;
+      case CORAL_OUT:
+        candle.setControl(
+            new StrobeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withFrameRate(4)
+                .withColor(new RGBWColor(0, 255, 0)));
+        break;
+      case ALGAE_OUT:
+        candle.setControl(
+            new StrobeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withFrameRate(4)
+                .withColor(new RGBWColor(0, 0, 255)));
+        break;
+      case CORAL_IN:
+        candle.setControl(
+            new StrobeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withFrameRate(8)
+                .withColor(new RGBWColor(255, 255, 255)));
+        break;
+      case CLIMBING:
+        candle.setControl(new RainbowAnimation(LED_START_INDEX, LED_END_INDEX).withFrameRate(60));
+      case AIR_GOOD: // >70
+        candle.setControl(
+            new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withColor(new RGBWColor(186, 85, 211))
+                .withFrameRate(2 * psi));
+      case AIR_LOW: // 40-70
+        candle.setControl(
+            new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withColor(new RGBWColor(255, 255, 0))
+                .withFrameRate(4 * psi));
+      case AIR_BAD: // <40
+        candle.setControl(
+            new SingleFadeAnimation(LED_START_INDEX, LED_END_INDEX)
+                .withColor(new RGBWColor(200, 0, 0))
+                .withFrameRate(8 * psi));
+    }
+  }
+}

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -16,10 +16,7 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.geometry.Twist2d;
+import edu.wpi.first.math.geometry.*;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
@@ -200,6 +197,14 @@ public class DriveSubsystem extends SubsystemBase {
   public double getPressurePSI() {
     double voltage = pressureSensor.getVoltage();
     return (250 * (voltage / 5.0)) - 25; // Example conversion
+  }
+
+  public Transform2d getVelocity() {
+    final var chassisSpeeds = kinematics.toChassisSpeeds(getModuleStates());
+    return new Transform2d(
+        chassisSpeeds.vxMetersPerSecond,
+        chassisSpeeds.vyMetersPerSecond,
+        new Rotation2d(chassisSpeeds.omegaRadiansPerSecond));
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -204,9 +204,10 @@ public class DriveSubsystem extends SubsystemBase {
         DriverStation.getAlliance().isPresent()
             && DriverStation.getAlliance().get() == DriverStation.Alliance.Red;
     // convert to field relative
-    ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(
-        kinematics.toChassisSpeeds(getModuleStates()),
-        isFlipped ? getRotation().plus(new Rotation2d(Math.PI)) : getRotation());
+    ChassisSpeeds chassisSpeeds =
+        ChassisSpeeds.fromRobotRelativeSpeeds(
+            kinematics.toChassisSpeeds(getModuleStates()),
+            isFlipped ? getRotation().plus(new Rotation2d(Math.PI)) : getRotation());
     return new Transform2d(
         chassisSpeeds.vxMetersPerSecond,
         chassisSpeeds.vyMetersPerSecond,
@@ -215,6 +216,7 @@ public class DriveSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
+    SmartDashboard.putString("Velocity", getVelocity().toString());
     Command currentCommand = this.getCurrentCommand();
     Logger.recordOutput(
         "current Command", currentCommand != null ? currentCommand.getName() : "None");

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -197,7 +197,7 @@ public class DriveSubsystem extends SubsystemBase {
     };
   }
 
-  private double getPressurePSI() {
+  public double getPressurePSI() {
     double voltage = pressureSensor.getVoltage();
     return (250 * (voltage / 5.0)) - 25; // Example conversion
   }

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -200,7 +200,13 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   public Transform2d getVelocity() {
-    final var chassisSpeeds = kinematics.toChassisSpeeds(getModuleStates());
+    boolean isFlipped =
+        DriverStation.getAlliance().isPresent()
+            && DriverStation.getAlliance().get() == DriverStation.Alliance.Red;
+    // convert to field relative
+    ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(
+        kinematics.toChassisSpeeds(getModuleStates()),
+        isFlipped ? getRotation().plus(new Rotation2d(Math.PI)) : getRotation());
     return new Transform2d(
         chassisSpeeds.vxMetersPerSecond,
         chassisSpeeds.vyMetersPerSecond,

--- a/src/main/java/frc/robot/subsystems/vision/CameraPoses.java
+++ b/src/main/java/frc/robot/subsystems/vision/CameraPoses.java
@@ -10,15 +10,13 @@ public class CameraPoses {
       new Pose3d[] {
         // Front Left
         new Pose3d(
-            new Translation3d(0.235, 0.235, 0.267), // Right camera translation (X, Y, Z)
-            new Rotation3d(0.0, Units.degreesToRadians(-12.63), Units.degreesToRadians(45))),
+            new Translation3d(0.256, 0.213, 0.267), // Right camera translation (X, Y, Z)
+            new Rotation3d(0.0, Units.degreesToRadians(-12.63), Units.degreesToRadians(-15))),
         // Front Right
         new Pose3d(
-            new Translation3d(0.235, -0.235, 0.267), // Left camera translation (X, Y, Z)
+            new Translation3d(0.268, -0.213, 0.267), // Left camera translation (X, Y, Z)
             new Rotation3d(
-                0.0,
-                Units.degreesToRadians(-12.63),
-                Units.degreesToRadians(-45))), // in radians btw
+                0.0, Units.degreesToRadians(-12.63), Units.degreesToRadians(45))), // in radians btw
         //        // Back Right
         new Pose3d(
             new Translation3d(-0.235, -0.235, 0.267), // Left camera translation (X, Y, Z)

--- a/vendordeps/Phoenix6-frc2025-latest.json
+++ b/vendordeps/Phoenix6-frc2025-latest.json
@@ -1,7 +1,7 @@
 {
   "fileName": "Phoenix6-frc2025-latest.json",
   "name": "CTRE-Phoenix (v6)",
-  "version": "25.3.2",
+  "version": "25.4.0",
   "frcYear": "2025",
   "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
   "mavenUrls": [
@@ -19,14 +19,14 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-java",
-      "version": "25.3.2"
+      "version": "25.4.0"
     }
   ],
   "jniDependencies": [
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "api-cpp",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -40,7 +40,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -54,7 +54,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "api-cpp-sim",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -68,7 +68,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -82,7 +82,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -96,7 +96,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -110,7 +110,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -124,7 +124,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -138,7 +138,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -152,7 +152,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFXS",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -166,7 +166,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -180,7 +180,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -194,7 +194,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANrange",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -208,7 +208,21 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANdi",
-      "version": "25.3.2",
+      "version": "25.4.0",
+      "isJar": false,
+      "skipInvalidPlatforms": true,
+      "validPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANdle",
+      "version": "25.4.0",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -224,7 +238,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-cpp",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_Phoenix6_WPI",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -240,7 +254,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_PhoenixTools",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -256,7 +270,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "wpiapi-cpp-sim",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_Phoenix6_WPISim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -272,7 +286,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_PhoenixTools_Sim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -288,7 +302,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimTalonSRX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -304,7 +318,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimVictorSPX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -320,7 +334,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimPigeonIMU",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -336,7 +350,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimCANCoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -352,7 +366,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProTalonFX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -368,7 +382,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFXS",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProTalonFXS",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -384,7 +398,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProCANcoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -400,7 +414,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProPigeon2",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -416,7 +430,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANrange",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProCANrange",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -432,8 +446,24 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANdi",
-      "version": "25.3.2",
+      "version": "25.4.0",
       "libName": "CTRE_SimProCANdi",
+      "headerClassifier": "headers",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANdle",
+      "version": "25.4.0",
+      "libName": "CTRE_SimProCANdle",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,


### PR DESCRIPTION
**LED Subsystem** (there are currently zero LEDs on the robot): 
- Triggers in the RobotContainer constantly toggle the LED mode
- Some triggers "lock" the LEDs, meaning that they will not change color
- LEDs must be "unlocked" to be allowed to change color

_The following colors lock the LEDs when activated:_
- Rainbow colors when disabled, starting up, or climbed
- Flash green when in scoring sequence
- Flash blue when in algae-removal sequence
- Flash white for 1 second when obtaining a coral

_These colors do not lock and therefore immediately change if the subsystem attempts to change:_
- Purple if PSI 70+
- Yellow if between 40-70
- Red if below 40

**Auto Targeting and Location Choosing**
- Driver controls remapped to aarav's ideal controls
- Manual elevator / scoring control capability added
- Reef face is automatically selected based on which face is closest
- Left/right is determined based on what the driver is holding (left bumper, right bumper, etc)